### PR TITLE
Add Figma

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
-# close-it-all
-Auto-close Zoom, and Slack tabs
+# Close It All
 
-Logo provided by <a href="https://www.vecteezy.com/free-vector/window-tab">Hyperbleh</a> on Vecteezy.
+Auto-close Zoom, Slack, and Figma tabs.
 
+Know of another service to add? Please send comments or PRs!
+
+### Figma Notice
+
+This extension is meant for use with the Figma desktop app and will prevent you from opening Figma projects in the browser (since the tab will be auto-closed). You can still open projects in the browser by going to [figma.com](https://figma.com) and choosing a project on the home screen.
 
 Chrome extension link: [here](https://chrome.google.com/webstore/detail/close-it-all/jajppoidhhhnpfobmlhpoegeiabpplcc)
-
-
 
 ## Future work
 
 - Add Bluejeans links
 
+## Credits
 
-
-Know of another service to add? Please send comments or PRs!
+Logo provided by <a href="https://www.vecteezy.com/free-vector/window-tab">Hyperbleh</a> on Vecteezy.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Close It All",
-    "description": "Automatically close Zoom, Slack, and Bluejeans windows",
-    "version": "1.0.0",
+    "description": "Automatically close Zoom, Slack, and Figma and tabs.",
+    "version": "1.0.1",
     "manifest_version": 3,
     "icons": {
         "16": "assets/icon-16.png",
@@ -36,7 +36,8 @@
                 "*://*.slack.com/huddle/*",
                 "*://*.slack-gov.com/huddle/*",
                 "*://*.slack.com/team/*",
-                "*://*.slack-gov.com/team/*"
+                "*://*.slack-gov.com/team/*",
+                "*://*.figma.com/file/*"
             ],
             "js": [
                 "content.js"


### PR DESCRIPTION
I added a match for Figma urls. Like other link opening applications, it leaves a trail of tabs behind. 😅
(Also tweaked the doc formatting a bit for clarity). 

One concern I have with this PR is that there is no differences between a redirect page url and a figma project url (when opened in the browser), effectively preventing a user from opening figma projects in the browser. This is probably ok for heavy Figma users as they'll be using the desktop app. However, for light figma users that do open projects in the browser (because they either don't have or want to avoid installing the desktop app), this PR might prevent them from using the extension to auto-close Zoom or Slack tabs.

It would be nice if the user could select what type of tabs they want to auto-close (Zoom, Slack or Figma) but I didn't find a way to do it with the manifest match. Other auto-closing implementations (for example [Zoom Tab Closer](https://github.com/grrttedwards/zoom-tab-closer) implement the auto-closing as a listener that then parses the tab urls to find a match. In this case, it would be easier to provide a way for the user to choose what to auto-close or not. However, the manifest solution seems more elegant and is probably more efficient, which is why I chose to update it. But maybe this is one limitation. 